### PR TITLE
fix:修复group组件下setValue时，长度与内容发生变化时不响应问题

### DIFF
--- a/components/element-ui/group/src/component.jsx
+++ b/components/element-ui/group/src/component.jsx
@@ -129,6 +129,7 @@ export default {
                 for (let i = len; i < 0; i++) {
                     this.addRule(n.length + i);
                 }
+                this.sort = Object.keys(this.cacheRule);
                 for (let i = 0; i < total; i++) {
                     this.setValue(keys[i], n[i]);
                 }
@@ -137,6 +138,7 @@ export default {
                     for (let i = 0; i < len; i++) {
                         this.removeRule(keys[total - i - 1]);
                     }
+                    this.sort = Object.keys(this.cacheRule);
                 }
                 n.forEach((val, i) => {
                     this.setValue(keys[i], n[i]);


### PR DESCRIPTION
由于时序问题this.sort没有及时更新，当内部有input类组件时。会产生数据丢失，以及报错。
[具体错误示例如](https://codepen.io/taye-cn/pen/PoxedGQ)


