### PR TITLE
fix: packages/element-ui中解决运行dev:ele报错

### DIFF
--- a/packages/element-ui/vue.config.js
+++ b/packages/element-ui/vue.config.js
@@ -24,5 +24,6 @@ module.exports = {
                 },
             ]
         }
-    }
+    },
+    transpileDependencies: ['@form-create']
 }


### PR DESCRIPTION
packages/element-ui运行dev:ele报错如下
![20241106-150701](https://github.com/user-attachments/assets/7a51c7ce-5d6e-4793-91bc-a61e2da9b73c)

原因是@vue/cli-plugin-babel默认情况下，babel-loader 会排除 node_modules 依赖内部的文件。如果希望显性编译一个依赖的模块，你需要将其添加入 vue.config.js 中的 transpileDependencies 选项：
