### PR TITLE
fix: Set a default format for naive-ui datePicker

### DIFF
--- a/packages/naive-ui/src/parsers/datePicker.js
+++ b/packages/naive-ui/src/parsers/datePicker.js
@@ -1,5 +1,17 @@
 import {creatorFactory} from '@form-create/core/src/index';
 
+const DEFAULT_FORMATS = {
+    date: 'yyyy-MM-dd',
+    month: 'yyyy-MM',
+    week: 'yyyy-wo',
+    datetime: 'yyyy-MM-dd HH:mm:ss',
+    timerange: 'HH:mm:ss',
+    daterange: 'yyyy-MM-dd',
+    monthrange: 'yyyy-MM',
+    datetimerange: 'yyyy-MM-dd HH:mm:ss',
+    year: 'yyyy'
+};
+
 const name = 'datePicker';
 
 export default {
@@ -10,5 +22,11 @@ export default {
             initial[type] = creatorFactory(name, {type: type.toLowerCase()});
             return initial
         }, {});
-    }())
+    }()),
+    mergeProp(ctx) {
+        const props = ctx.prop.props
+        if(!props.valueFormat) {
+            props.format = DEFAULT_FORMATS[props.type] || DEFAULT_FORMATS['date'];
+        }
+    }
 }


### PR DESCRIPTION
add `DEFAULT_FORMATS`
[Naive-ui datepicker 规则读取不到值，value是undefined #759](https://github.com/xaboy/form-create/issues/759)