### PR TITLE
fix: add ElInputTag support for auto-import in element-ui package (#825)

### DIFF
--- a/packages/element-ui/auto-import.js
+++ b/packages/element-ui/auto-import.js
@@ -27,7 +27,9 @@ import {
     ElUpload,
     ElIcon,
     ElProgress,
+    ElInputTag,
 } from 'element-plus';
+import 'element-plus/es/components/input-tag/style/css'
 import 'element-plus/es/components/button/style/css'
 import 'element-plus/es/components/form/style/css'
 import 'element-plus/es/components/form-item/style/css'
@@ -87,6 +89,7 @@ export default function install(formCreate) {
         app.component(ElIcon.name) || app.use(ElIcon);
         app.component(ElTimePicker.name) || app.use(ElTimePicker);
         app.component(ElProgress.name) || app.use(ElProgress);
+        app.component(ElInputTag.name) || app.use(ElInputTag);
     });
 
 }

--- a/packages/element-ui/src/core/alias.js
+++ b/packages/element-ui/src/core/alias.js
@@ -26,6 +26,7 @@ export default {
     col: PRE + '-col',
     row: PRE + '-row',
     tree: 'fc-tree',
+    inputTag: PRE + '-input-tag',
     autoComplete: PRE + '-autocomplete',
     auto: PRE + '-autocomplete',
     group: 'fc-group',

--- a/packages/element-ui/src/core/maker.js
+++ b/packages/element-ui/src/core/maker.js
@@ -9,12 +9,13 @@ useUpload(maker);
 useFrame(maker);
 
 function useAlias(maker) {
-    ['group', 'tree', 'switch', 'upload', 'autoComplete', 'checkbox', 'cascader', 'colorPicker', 'datePicker', 'frame', 'inputNumber', 'radio', 'rate'].forEach(name => {
+    ['group', 'tree', 'switch', 'upload', 'autoComplete', 'checkbox', 'cascader', 'colorPicker', 'datePicker', 'frame', 'inputNumber', 'inputTag', 'radio', 'rate'].forEach(name => {
         maker[name] = creatorFactory(name);
     });
     maker.auto = maker.autoComplete;
     maker.number = maker.inputNumber;
     maker.color = maker.colorPicker;
+    maker.tag = maker.inputTag;
 }
 
 function useSelect(maker) {

--- a/packages/element-ui/types/maker.d.ts
+++ b/packages/element-ui/types/maker.d.ts
@@ -4,7 +4,7 @@ import {CreatorAttrs, OptionAttrs, RuleAttrs, ApiAttrs} from "./config";
 declare const makerFactory: CreatorHelper<OptionAttrs, CreatorAttrs, RuleAttrs, ApiAttrs>
 
 declare enum MakerName {
-    "datePicker", "year", "month", "date", "dates", "week", "datetime", "datetimeRange", "dateRange", "monthRange", "hidden", "input", "password", "url", "email", "text", "textarea", "idate", "slider", "sliderRange", "timePicker", "time", "timeRange", "group", "tree", "switch", "upload", "autoComplete", "checkbox", "cascader", "colorPicker", "frame", "inputNumber", "radio", "rate", "select", "auto", "number", "color", "selectMultiple", "selectOne", "treeSelected", "treeChecked", "image", "file", "uploadFileOne", "uploadImageOne", "uploadImage", "uploadFile", "frameInputs", "frameFiles", "frameImages", "frameInputOne", "frameFileOne", "frameImageOne", "frameInput", "frameFile", "frameImage"
+    "datePicker", "year", "month", "date", "dates", "week", "datetime", "datetimeRange", "dateRange", "monthRange", "hidden", "input", "password", "url", "email", "text", "textarea", "idate", "slider", "sliderRange", "timePicker", "time", "timeRange", "group", "tree", "switch", "upload", "autoComplete", "checkbox", "cascader", "colorPicker", "frame", "inputNumber", "inputTag", "tag", "radio", "rate", "select", "auto", "number", "color", "selectMultiple", "selectOne", "treeSelected", "treeChecked", "image", "file", "uploadFileOne", "uploadImageOne", "uploadImage", "uploadFile", "frameInputs", "frameFiles", "frameImages", "frameInputOne", "frameFileOne", "frameImageOne", "frameInput", "frameFile", "frameImage"
 }
 
 type Maker = {


### PR DESCRIPTION
关联 Issue
Closes #825 

为 element-ui 包添加 ElInputTag 按需加载支持 (#825)
问题描述
Element Plus 的 ElInputTag（标签输入框）组件未在 @form-create/element-ui 的 auto-import.js 中注册，导致使用按需加载时该组件无法正常工作。

修改内容
auto-import.js: 添加 ElInputTag 组件的导入及 element-plus/es/components/input-tag/style/css 样式的按需引入，并在 install 函数中注册该组件
alias.js: 添加 inputTag: 'el-input-tag' 别名映射，支持通过 type: 'inputTag' 使用该组件
maker.js: 在 useAlias 中添加 inputTag 的 maker factory，并增加 tag 作为 inputTag 的快捷别名
maker.d.ts: 在 MakerName 枚举中添加 "inputTag" 和 "tag" 类型声明
